### PR TITLE
Drop video stream from merged files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,8 +109,8 @@ ignore_missing_imports = true
 
 ## Pytest
 [tool.pytest.ini_options]
-log_level="DEBUG"
-
+log_level = "DEBUG"
+xfail_strict = true
 
 ## Pylint
 [tool.pylint.'MESSAGES CONTROL']

--- a/src/audio_feeder/m4btools.py
+++ b/src/audio_feeder/m4btools.py
@@ -230,8 +230,10 @@ def _merge_subsets(
             "0",
             "-c:a",
             audio_codec,
-            "-c:v",
-            "copy",
+            "-map",
+            "-v?",
+            "-map",
+            "-V?",
             os.fspath(out_path),
         ]
 
@@ -299,8 +301,12 @@ def _extract_subset(
         "1",
         "-map_metadata",
         "0",
-        "-c",
+        "-c:a",
         "copy",
+        "-map",
+        "-v?",
+        "-map",
+        "-V?",
         os.fspath(out_path),
     ]
 

--- a/tests/test_m4btools.py
+++ b/tests/test_m4btools.py
@@ -930,9 +930,6 @@ def m4bs_with_cover(
     yield file1, file2
 
 
-@pytest.mark.xfail(
-    raises=IOError, reason="Video channel causes ffmpeg concatenation to fail"
-)
 @pytest.mark.parametrize(
     "job_maker, output_filename",
     [


### PR DESCRIPTION
Maybe at some point in the future we'll want to make sure that these are included, but at the moment it can cause some problems when a file has embeded cover art. It is possible that we need to use a different container to allow for embedded cover art.

This needs:

- [x] A test
- [ ] An investigation into why these errors aren't bubbling up into the media renderer.