### PR TITLE
Add token to setup-ffmpeg to fix rate limiting

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,8 +26,10 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.x'
-    - uses: FedericoCarboni/setup-ffmpeg@v1
+    - uses: FedericoCarboni/setup-ffmpeg@v2
       id: setup-ffmpeg
+      with:
+        token: ${{ secrets.GH_API_TOKEN }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,10 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: FedericoCarboni/setup-ffmpeg@v1
+    - uses: FedericoCarboni/setup-ffmpeg@v2
       id: setup-ffmpeg
+      with:
+        token: ${{ secrets.GH_API_TOKEN }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
The setup-ffmpeg job pulls from the github API, and it always comes from the same IP on GHA, which means that it is getting rate limited, see: https://github.com/FedericoCarboni/setup-ffmpeg/issues/4

You can fix this by authenticating your requests.