### PR TITLE
Pin SQLAlchemy to <2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "click>=6.0",
     "progressbar2",
     "lxml>=2.0",
-    "SQLAlchemy>=1.4",
+    "SQLAlchemy>=1.4,<2",
     "attrs>=22.0",
     "backports.strenum>=1.1.1;python_version<'3.11'",
     "typing_extensions>=4.0.0;python_version<'3.11'",

--- a/src/audio_feeder/sql_database_handler.py
+++ b/src/audio_feeder/sql_database_handler.py
@@ -273,10 +273,12 @@ class SqlDatabaseHandler:
         if not self._db.exists():
             _metadata_object().create_all(self.engine)
             with self.session() as session:
+                assert session is not None
                 session.execute(f"PRAGMA user_version={DB_VERSION}")
         else:
             with self.session() as session:
-                db_version: int = session.execute("PRAGMA user_version").first()[0]  # type: ignore[index]
+                assert session is not None
+                db_version: int = session.execute("PRAGMA user_version").first()[0]  # type: ignore[index,assignment]
                 if db_version < DB_VERSION:
                     logging.info(
                         "Upgrading database from %s to %s", db_version, DB_VERSION
@@ -316,12 +318,14 @@ class SqlDatabaseHandler:
 
     def save_table(self, table_name: TableName, table_contents: Table) -> None:
         with self.session() as session:
+            assert session is not None
             self._save_table(session, table_name, table_contents)
             session.commit()
 
     def save_database(self, database: Database) -> None:
         self._initialize_db()
         with self.session() as session:
+            assert session is not None
             for table_name, contents in database.items():
                 self._save_table(session, table_name, contents)
 

--- a/tox.ini
+++ b/tox.ini
@@ -85,7 +85,7 @@ description = Run typechecking
 deps =
     attrs
     click
-    mypy>=0.991
+    mypy>=0.991,<1
     types-requests
     types-lxml
     types-pyyaml


### PR DESCRIPTION
Apparently this is broken by some of the breaking changes in 2.0. Most obviously the `PRAGMA user_version` statements need to be `sqlalchemy.sql.text` objects, not strings.