### PR TITLE
Format codebase with black

### DIFF
--- a/src/audio_feeder/_db_types.py
+++ b/src/audio_feeder/_db_types.py
@@ -13,6 +13,7 @@ MutableTable = typing.MutableMapping[ID, SchemaObject]
 Database = typing.Mapping[TableName, Table]
 MutableDatabase = typing.MutableMapping[TableName, MutableTable]
 
+
 # pragma: nocover
 class DatabaseHandler(typing.Protocol):
     def __init__(self, db_loc: PathType):

--- a/src/audio_feeder/_object_types.py
+++ b/src/audio_feeder/_object_types.py
@@ -9,6 +9,7 @@ from ._compat import Self
 
 ID = typing.NewType("ID", int)
 
+
 # TODO: When attrs > 22.1 is released, this should be an AttrsInstance
 # pragma: nocover
 class SchemaObject(typing.Protocol):

--- a/src/audio_feeder/config.py
+++ b/src/audio_feeder/config.py
@@ -325,7 +325,6 @@ class Configuration:
             return value
 
     def _make_replacements(self) -> None:
-
         replacements = self._replacements
         for field in attrs.fields(self.__class__):
             attrib = getattr(self, field.name)

--- a/src/audio_feeder/pages.py
+++ b/src/audio_feeder/pages.py
@@ -367,7 +367,6 @@ def _evaluate_bool_param(param: str) -> bool:
 
 @root.route("/update")
 def update():
-
     with UPDATE_LOCK:
         if not updater.UPDATE_IN_PROGRESS:
             reload_metadata: bool = request.args.get(

--- a/src/audio_feeder/sql_database_handler.py
+++ b/src/audio_feeder/sql_database_handler.py
@@ -104,7 +104,6 @@ class _PathCollection(_CustomJsonType):
 
 class _CoverImages(_CustomJsonType):
     def process_result_value(self, value: str, dialect):
-
         json_obj = self._load_json(value)
 
         if json_obj is None:
@@ -123,7 +122,6 @@ class _CoverImages(_CustomJsonType):
 
 class _FileMetadata(_CustomJsonType):
     def process_result_value(self, value: str, dialect):
-
         json_obj = self._load_json(value)
         if json_obj is None:
             return None

--- a/src/audio_feeder/updater.py
+++ b/src/audio_feeder/updater.py
@@ -121,7 +121,6 @@ class BookDatabaseUpdater:
         # Drop any paths from the table that don't exist anymore
         media_loc_path: pathlib.Path = read_from_config("media_loc").path
         for path, e_id in id_by_path.items():
-
             if path is None or not (media_loc_path / path).exists():
                 del entry_table[e_id]
 
@@ -522,7 +521,6 @@ class BookDatabaseUpdater:
         if bt_id not in books_by_key or len(books_by_key[bt_id]) < len(
             book_table.items()
         ):
-
             if bt_id in books_by_key:
                 books_by_key_cache = books_by_key[bt_id]
                 cached_book_id_set = cached_book_ids[bt_id]
@@ -833,7 +831,6 @@ def update(
     reload_metadata: bool = False,
     check_hashes: bool = False,
 ) -> None:
-
     if path is None:
         path = "."
 
@@ -882,7 +879,6 @@ def _generate_thumbnail(img_loc: PathType, thumb_loc: PathType) -> None:
 
 
 def _get_img_ext(fobj: typing.BinaryIO) -> str:
-
     img = Image.open(fobj)
     img_type = img.format
     ext_map = {

--- a/tests/test_segmenter.py
+++ b/tests/test_segmenter.py
@@ -50,7 +50,6 @@ def brute_force_minimization(
 def segment_with_score(
     arr: typing.Sequence[segmenter.Scorable], cost_func: segmenter.CostFunc
 ) -> typing.Tuple[typing.Sequence[typing.Sequence[segmenter.Scorable]], float]:
-
     sequence = segmenter.segment(arr, cost_func)
     scorer = make_segmentation_scorer(cost_func)
     return sequence, scorer(sequence)


### PR DESCRIPTION
I'm guessing something changed about black that requires a re-format of the codebase, since the `lint` target is now failing.